### PR TITLE
Clarify README parameters explanations

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -18,18 +18,18 @@ available_architectures:
 param_container_name: "{{ project_name }}"
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "<path to data>", desc: "database and healthchecks config" }
+  - { vol_path: "/config", vol_host_path: "<path to data on host>", desc: "database and healthchecks config directory volume mapping" }
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "SITE_ROOT", env_value: "<SITE_ROOT>", desc: "The site's domain (i.e., example.com)" }
-  - { env_var: "SITE_NAME", env_value: "<SITE_NAME>", desc: "The site's name" }
+  - { env_var: "SITE_ROOT", env_value: "<SITE_ROOT>", desc: "The site's top-level URL (e.g., https://healthchecks.example.com)" }
+  - { env_var: "SITE_NAME", env_value: "<SITE_NAME>", desc: "The site's name (e.g., \"Example Corp HealthChecks\")"}
   - { env_var: "DEFAULT_FROM_EMAIL", env_value: "<DEFAULT_FROM_EMAIL>", desc: "From email for alerts" }
   - { env_var: "EMAIL_HOST", env_value: "<EMAIL_HOST>", desc: "SMTP host" }
   - { env_var: "EMAIL_PORT", env_value: "<EMAIL_PORT>", desc: "SMTP port"}
   - { env_var: "EMAIL_HOST_USER", env_value: "<EMAIL_HOST_USER>", desc: "SMTP user"}
   - { env_var: "EMAIL_HOST_PASSWORD", env_value: "<EMAIL_HOST_PASSWORD>", desc: "SMTP password"}
-  - { env_var: "EMAIL_USE_TLS", env_value: "<EMAIL_USE_TLS>", desc: "Use TLS for SMTP"}
-  - { env_var: "ALLOWED_HOSTS", env_value: "<ALLOWED_HOSTS>", desc: "array of valid hostnames for the server [\"test.com\",\"test2.com\"]"}
+  - { env_var: "EMAIL_USE_TLS", env_value: "<EMAIL_USE_TLS>", desc: "Use TLS for SMTP (`True` or `False`)"}
+  - { env_var: "ALLOWED_HOSTS", env_value: "<ALLOWED_HOSTS>", desc: "array of valid hostnames for the server `[\"test.com\",\"test2.com\"]` or `\"*\"`"}
   - { env_var: "SUPERUSER_EMAIL", env_value: "<SUPERUSER_EMAIL>", desc: "Superuser emai"}
   - { env_var: "SUPERUSER_PASSWORD", env_value: "<SUPERUSER_PASSWORD>", desc: "Superuser password"}
 


### PR DESCRIPTION
## Description:
This PR clarifies and corrects (in the case of `SITE_ROOT`) the information in the Parameters table. It also adds a clarification to the volume flag's example value.

## Benefits of this PR and context:
I had trouble getting the healthchecks container working due to some of the parameter meanings and valid values being unclear. For these parameters, I had to search the heathchecks documentation to discover what valid values could be.

## How Has This Been Tested?
Since this is a small documentation improvement, no testing beyond firing up a working container has been done.

## Source / References:
https://github.com/healthchecks/healthchecks#configuration