### PR TITLE
Fixed mariadb/postgresql dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
 	zlib-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
-	mariadb-connector-c \
+	mariadb-client \
 	postgresql-client \
 	python3 \
 	uwsgi \
@@ -43,8 +43,6 @@ RUN \
  echo "**** install pip packages ****" && \
  cd /app/healthchecks && \
  pip3 install --no-cache-dir -r requirements.txt && \
- pip3 install \
- 	mysqlclient && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
 	mariadb-connector-c \
+	postgresql-client \
 	python3 \
 	uwsgi \
 	uwsgi-python3 && \
@@ -43,8 +44,7 @@ RUN \
  cd /app/healthchecks && \
  pip3 install --no-cache-dir -r requirements.txt && \
  pip3 install \
- 	mysqlclient \
-	postgres && \
+ 	mysqlclient && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -24,6 +24,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
         mariadb-connector-c \
+	postgresql-client \
 	python3 \
 	uwsgi \
 	uwsgi-python3 && \
@@ -43,8 +44,7 @@ RUN \
  cd /app/healthchecks && \
  pip3 install --no-cache-dir -r requirements.txt && \
  pip3 install \
- 	mysqlclient \
-	postgres && \
+ 	mysqlclient && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,7 +23,7 @@ RUN \
 	zlib-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
-        mariadb-connector-c \
+        mariadb-client \
 	postgresql-client \
 	python3 \
 	uwsgi \
@@ -43,8 +43,6 @@ RUN \
  echo "**** install pip packages ****" && \
  cd /app/healthchecks && \
  pip3 install --no-cache-dir -r requirements.txt && \
- pip3 install \
- 	mysqlclient && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -24,6 +24,7 @@ RUN \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
         mariadb-connector-c \
+	postgresql-client \
 	python3 \
 	uwsgi \
 	uwsgi-python3 && \
@@ -43,8 +44,7 @@ RUN \
  cd /app/healthchecks && \
  pip3 install --no-cache-dir -r requirements.txt && \
  pip3 install \
- 	mysqlclient \
-	postgres && \
+ 	mysqlclient && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -23,7 +23,7 @@ RUN \
 	zlib-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache --upgrade \
-        mariadb-connector-c \
+        mariadb-client \
 	postgresql-client \
 	python3 \
 	uwsgi \
@@ -43,8 +43,6 @@ RUN \
  echo "**** install pip packages ****" && \
  cd /app/healthchecks && \
  pip3 install --no-cache-dir -r requirements.txt && \
- pip3 install \
- 	mysqlclient && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
- Fixed mariadb/postgresql dependencies ( multiarch ), packages are now resolved from apt.
- It does not work with postgres from pypi, nor psycopg2, psycopg2-binary
Log:
```
ImportError: Error loading shared library libpq.so.5: No such file or directory (needed by /usr/lib/python3.7/site-packages/psycopg2/_psycopg.cpython-37m-x86_64-linux-gnu.so)
```

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Working connection to external PostgreSQL and MariaDB
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
---
version: "2"
services:
  healthchecks:
    image: mycustomhealtchsimage
    environment:
      PUID: "1000"
      PGID: "1000"
      TZ: "Europe/Prague"
      SITE_ROOT: "https://healthchecks.example.com"
      SITE_NAME: "healtchecks"
      REGISTRATION_OPEN: "False"
      SUPERUSER_EMAIL: "admin@admin.admin"
      SUPERUSER_PASSWORD: "admin"
      DB: healthchecks
      #DB_HOST: healthchecks-postgres
      DB_HOST: healthchecks-mariadb
      DB_NAME: healtchecks
      DB_USER: healtchecks
      DB_PASSWORD: healtchecks
    networks: 
      - production-network
    restart: unless-stopped
    ports:
      - "8000:8000"
    depends_on:
      - healthchecks-postgres
  healthchecks-postgres:
    image: postgres:12-alpine
    environment:
      POSTGRES_DB: healthchecks
      POSTGRES_USER: healthchecks
      POSTGRES_PASSWORD: healthchecks
      TZ: Europe/Prague
    networks: 
      - production-network
    restart: unless-stopped
  healthchecks-mariadb:
    image: mariadb:10.4.10-bionic
    environment:
      MYSQL_RANDOM_ROOT_PASSWORD: yes
      MYSQL_DATABASE: healthchecks
      MYSQL_USER: healthchecks
      MYSQL_PASSWORD: healthchecks
      TZ: Europe/Prague
    networks: 
      - production-network
    restart: unless-stopped
    
networks:
  production-network:
    ipam:
     driver: default
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
