### PR TITLE
remove unused CSRF_HOST

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -27,7 +27,6 @@ if [ ! -f "/config/local_settings.py" ]; then
 			fi
 		fi
 	done
-	$CSRF_HOST = $(${HC_CONF[SITE_ROOT]}/)
 	echo "ALLOWED_HOSTS = [\"${HC_CONF[BASE_URL]}\"]" >> /config/local_settings.py
 	echo "CSRF_TRUSTED_ORIGINS = [\"${HC_CONF[BASE_URL]}\"]" >> /config/local_settings.py
 	echo "PING_ENDPOINT = SITE_ROOT + \"/ping/\"" >> /config/local_settings.py


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
CSRF_HOST is unused and throws an error on startup of the container.

```
[cont-init.d] 30-config: executing...
/var/run/s6/etc/cont-init.d/30-config: line 30: http://localhost/: No such file or directory
/var/run/s6/etc/cont-init.d/30-config: line 30: =: command not found
```

## Benefits of this PR and context:
fixes an error during startup of the container

## How Has This Been Tested?
tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
resolves #47 
