### PR TITLE
Allowing an opt-in method to regenerate settings file from environment variables

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,6 +32,7 @@ param_env_vars:
   - { env_var: "ALLOWED_HOSTS", env_value: "<ALLOWED_HOSTS>", desc: "array of valid hostnames for the server `[\"test.com\",\"test2.com\"]` or `\"*\"`"}
   - { env_var: "SUPERUSER_EMAIL", env_value: "<SUPERUSER_EMAIL>", desc: "Superuser email"}
   - { env_var: "SUPERUSER_PASSWORD", env_value: "<SUPERUSER_PASSWORD>", desc: "Superuser password"}
+  - { env_var: "REGENERATE_SETTINGS", env_value: "True/False", desc: "Defaults to False. Set to true to always override the `local_settings.py` file with values from environment variables. Do not set to True if you have made manual modifications to this file."}
 
 param_usage_include_ports: true
 param_ports:

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -16,8 +16,9 @@ HC_CONF[EMAIL_PORT]=${EMAIL_PORT:-587}
 HC_CONF[EMAIL_HOST_USER]=${EMAIL_HOST_USER:-username}
 HC_CONF[EMAIL_HOST_PASSWORD]=${EMAIL_HOST_PASSWORD:-password}
 HC_CONF[EMAIL_USE_TLS]=${EMAIL_USE_TLS:-True}
+HC_CONF[REGENERATE_SETTINGS]=${REGENERATE_SETTINGS:-False}
 
-if [ ! -f "/config/local_settings.py" ]; then
+if [ ! -f "/config/local_settings.py" ] || [[ ${HC_CONF[REGENERATE_SETTINGS]} == True ]]; then
 	# sed in values or skip if value not set
 	for KEY in "${!HC_CONF[@]}"; do
 		if [[ ! ${HC_CONF[$KEY]} == "" ]]; then


### PR DESCRIPTION
Fixes #54

In this issue I offered 3 solutions. This PR addresses the third option, what I hope is a "best of both worlds" - users can continue to maintain their settings file manually, while _given the option_ to allow the generator code to recreate the settings file if they so wish.

This, at least mostly, fills in the gap of the usefulness of the environment variables. With this change, users will at a minimum have some information about when the environment variables are used.

This will **not** create a breaking change, as users must **opt-in** to allowing regeneration of the settings file. The default is `False`, so it will not alter the existing logic unless it is explicitly set.
