### PR TITLE
Add SECRET_KEY to env documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ services:
       - ALLOWED_HOSTS=<ALLOWED_HOSTS>
       - SUPERUSER_EMAIL=<SUPERUSER_EMAIL>
       - SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD>
-      - SECRET_KEY=<SECRET_KEY>
       - REGENERATE_SETTINGS=True/False
     volumes:
       - <path to data on host>:/config
@@ -114,7 +113,6 @@ docker run -d \
   -e ALLOWED_HOSTS=<ALLOWED_HOSTS> \
   -e SUPERUSER_EMAIL=<SUPERUSER_EMAIL> \
   -e SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD> \
-  -e SECRET_KEY=<SECRET_KEY>
   -e REGENERATE_SETTINGS=True/False \
   -p 8000:8000 \
   -v <path to data on host>:/config \
@@ -143,7 +141,6 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e ALLOWED_HOSTS=<ALLOWED_HOSTS>` | array of valid hostnames for the server `["test.com","test2.com"]` or `"*"` |
 | `-e SUPERUSER_EMAIL=<SUPERUSER_EMAIL>` | Superuser email |
 | `-e SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD>` | Superuser password |
-| `-e SECRET_KEY=<SECRET_KEY>` | Secures HTTP sessions, set to a random value |
 | `-e REGENERATE_SETTINGS=True/False` | Defaults to False. Set to true to always override the `local_settings.py` file with values from environment variables. Do not set to True if you have made manual modifications to this file. |
 | `-v /config` | database and healthchecks config directory volume mapping |
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ services:
       - ALLOWED_HOSTS=<ALLOWED_HOSTS>
       - SUPERUSER_EMAIL=<SUPERUSER_EMAIL>
       - SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD>
+      - SECRET_KEY=<SECRET_KEY>
       - REGENERATE_SETTINGS=True/False
     volumes:
       - <path to data on host>:/config
@@ -113,6 +114,7 @@ docker run -d \
   -e ALLOWED_HOSTS=<ALLOWED_HOSTS> \
   -e SUPERUSER_EMAIL=<SUPERUSER_EMAIL> \
   -e SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD> \
+  -e SECRET_KEY=<SECRET_KEY>
   -e REGENERATE_SETTINGS=True/False \
   -p 8000:8000 \
   -v <path to data on host>:/config \
@@ -141,6 +143,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e ALLOWED_HOSTS=<ALLOWED_HOSTS>` | array of valid hostnames for the server `["test.com","test2.com"]` or `"*"` |
 | `-e SUPERUSER_EMAIL=<SUPERUSER_EMAIL>` | Superuser email |
 | `-e SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD>` | Superuser password |
+| `-e SECRET_KEY=<SECRET_KEY>` | Secures HTTP sessions, set to a random value |
 | `-e REGENERATE_SETTINGS=True/False` | Defaults to False. Set to true to always override the `local_settings.py` file with values from environment variables. Do not set to True if you have made manual modifications to this file. |
 | `-v /config` | database and healthchecks config directory volume mapping |
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,6 +32,7 @@ param_env_vars:
   - { env_var: "ALLOWED_HOSTS", env_value: "<ALLOWED_HOSTS>", desc: "array of valid hostnames for the server `[\"test.com\",\"test2.com\"]` or `\"*\"`"}
   - { env_var: "SUPERUSER_EMAIL", env_value: "<SUPERUSER_EMAIL>", desc: "Superuser email"}
   - { env_var: "SUPERUSER_PASSWORD", env_value: "<SUPERUSER_PASSWORD>", desc: "Superuser password"}
+  - { env_var: "SECRET_KEY", env_value: "<SECRET_KEY>", desc: "Secures HTTP sessions, set to a random value"}
   - { env_var: "REGENERATE_SETTINGS", env_value: "True/False", desc: "Defaults to False. Set to true to always override the `local_settings.py` file with values from environment variables. Do not set to True if you have made manual modifications to this file."}
 
 param_usage_include_ports: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-healthchecks/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description & Benefits of this PR and context:
<!--- Describe your changes in detail -->
The official Healthchecks image says to [include a `SECRET_KEY` env var](https://github.com/healthchecks/healthchecks/tree/master/docker), but this image doesn't, which leads to a banner at the top of the page saying "Running with an insecure SECRET_KEY value, do not use in production."
Simply adding the env var gets rid of this message in the current linuxserver image, so I figured it would be good to document it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I'm using `SECRET_KEY` on my container.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/healthchecks/healthchecks/tree/master/docker