### PR TITLE
Update uwsgi.ini

### DIFF
--- a/root/defaults/uwsgi.ini
+++ b/root/defaults/uwsgi.ini
@@ -1,5 +1,6 @@
 [uwsgi]
 http-socket = :8000
+buffer-size = 32768
 enable-threads
 plugin = python3
 module = hc.wsgi:application


### PR DESCRIPTION
This is a pull request for the following issue:
https://github.com/linuxserver/docker-healthchecks/issues/67

When using this container behind a Traefik reverse proxy and forward authentication the webserver errors out with the message that the header size is bigger the 4096.

This pull request increases the header size in the following file: /app/healthchecks/uwsgi.ini