### PR TITLE
Fix CSRF setting for Django 4.0 (introduced in v1.25.0)

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "08.01.22:", desc: "Fix CSRF setting for Django 4.0 (introduced in v1.25.0)"}
   - { date: "10.09.21:", desc: "Fix creation of superuser"}
   - { date: "07.08.21:", desc: "Update custom logo handling to support changes in v1.22.0" }
   - { date: "11.07.21:", desc: "Rebase to Alpine 3.14." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -90,7 +90,7 @@ if [ ! -f "/config/local_settings.py" ] || [[ "${REGENERATE_SETTINGS}" == "True"
              fi
         fi
     done
-    insert_config "CSRF_TRUSTED_ORIGINS" "[\"${BASE_URL}\"]"
+    insert_config "CSRF_TRUSTED_ORIGINS" "[\"${SITE_ROOT}\"]"
 fi
 
 if [[ -z "$SECRET_KEY" ]] && ! grep "SECRET_KEY" /config/local_settings.py &> /dev/null; then

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -6,11 +6,6 @@ if [ -d /app/healthchecks-tmp ]; then
     chown -R abc:abc /app
 fi
 
-# set default values for variables
-if [ -n "${SITE_ROOT}" ]; then
-    BASE_URL=$(echo "${SITE_ROOT}" | sed -E 's/https?:\/\///' | awk -F/ '{ print $1 }' )
-fi
-
 #From https://healthchecks.io/docs/self_hosted_configuration/
 HC_CONF=(
 ALLOWED_HOSTS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-healthchecks/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Healthchecks v1.25.0 has upgraded Django to 4.0 and so the CSRF host should include the `http(s)://` prefix. 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Fixes an error produced by the change in upstream. The error is visible in the Docker logs and echoed regularly in context of alert sending. It might broke the alert sending functionality but that's not confirmed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Edited my local settings file within the container, instantly remediated the issue. 

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
```
SystemCheckError: System check identified some issues:

ERRORS:
?: (4_0.E001) As of Django 4.0, the values in the CSRF_TRUSTED_ORIGINS setting
must start with a scheme (usually http:// or https://) but found XXXXFQDNXXXX.com. See the release notes for details.
[uwsgi-daemons] respawning "/usr/bin/python3 ./manage.py sendalerts" (uid: 1100
 gid: 1100)
```