### PR TITLE
Fix CSRF handling

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,11 +33,12 @@ param_env_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "REGENERATE_SETTINGS", env_value: "", desc: "Defaults to False. Set to True to always override the `local_settings.py` file with values from environment variables. Do not set to True if you have made manual modifications to this file."}
-  - { env_var: "ALLOWED_HOSTS", env_value: "", desc: "Array of valid hostnames for the server `[\"test.com\",\"test2.com\"]` (default: `[\"*\"]`)"}
+  - { env_var: "ALLOWED_HOSTS", env_value: "", desc: "A [list](https://docs.python.org/3/tutorial/introduction.html#lists) of valid hostnames for the server. Default is: `[\"*\"]`"}
+  - { env_var: "CSRF_TRUSTED_ORIGINS", env_value: "", desc: "A [list](https://docs.python.org/3/tutorial/introduction.html#lists) of trusted origins for unsafe requests (e.g. POST). Defaults to the value of `SITE_ROOT`."}
   - { env_var: "APPRISE_ENABLED", env_value: "", desc: "Defaults to False. A boolean that turns on/off the Apprise integration (https://github.com/caronc/apprise)" }
   - { env_var: "DEBUG", env_value: "", desc: "Defaults to True. Debug mode relaxes CSRF protections and increases logging verbosity but should be disabled for production instances as it will impact performance and security."}
   - { env_var: "INTEGRATIONS_ALLOW_PRIVATE_IPS", env_value: "", desc: "Defaults to False. Set to True to allow integrations to connect to private IP addresses."}
-  - { env_var: "PING_EMAIL_DOMAIN", env_value: "", desc: "The domain to use for generating ping email addresses."}  
+  - { env_var: "PING_EMAIL_DOMAIN", env_value: "", desc: "The domain to use for generating ping email addresses."}
   - { env_var: "SECRET_KEY", env_value: "", desc: "A secret key used for cryptographic signing. Will generate a secure value if one is not supplied" }
   - { env_var: "SITE_LOGO_URL", env_value: "", desc: "Full URL to custom site logo"}
 
@@ -53,12 +54,9 @@ app_setup_block_enabled: true
 app_setup_block: |
   Access the WebUI at <your-ip>:8000. For more information, check out [Healthchecks](https://github.com/healthchecks/healthchecks).
 
-  ## Note on `CSRF_TRUSTED_ORIGINS`
-
-  On first run (or any startup where `REGENERATE_SETTINGS=true`) we will set `CSRF_TRUSTED_ORIGINS` to match the value of `SITE_ROOT`. If you need different/additional origins, you will need to edit `/config/local_settings.py` and add them yourself. Note that setting `REGENERATE_SETTINGS=true` will overwrite any changes on startup.
-
 # changelog
 changelogs:
+  - { date: "22.01.24:", desc: "Fix CSRF handling."}
   - { date: "23.12.23:", desc: "Rebase to Alpine 3.19."}
   - { date: "31.05.23:", desc: "Rebase to Alpine 3.18. Deprecate armhf."}
   - { date: "22.12.22:", desc: "Rebase to Alpine 3.17. Add extra deps for pycurl. Add INTEGRATIONS_ALLOW_PRIVATE_IPS."}

--- a/root/etc/s6-overlay/s6-rc.d/init-healthchecks-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-healthchecks-config/run
@@ -81,6 +81,11 @@ function insert_config() {
     fi
 }
 
+if [[ -z ${SITE_ROOT} ]]; then
+    echo "No SITE_ROOT provided, halting init"
+    sleep infinity
+fi
+
 if [[ ! -f "/config/local_settings.py" ]] || [[ "${REGENERATE_SETTINGS,,}" == "true" ]]; then
     touch /config/local_settings.py
     for CONF in "${HC_CONF[@]}"; do
@@ -93,10 +98,9 @@ if [[ ! -f "/config/local_settings.py" ]] || [[ "${REGENERATE_SETTINGS,,}" == "t
         fi
     done
     if [[ -n ${CSRF_TRUSTED_ORIGINS} ]]; then
-        insert_config "CSRF_TRUSTED_ORIGINS" "[\"${CSRF_TRUSTED_ORIGINS}\"]"
+        insert_config "CSRF_TRUSTED_ORIGINS" "${CSRF_TRUSTED_ORIGINS}"
     else
-        insert_config "CSRF_TRUSTED_ORIGINS" "[]"
-        echo "WARNING: CSRF_TRUSTED_ORIGINS is set to allow connections from all origins, this is insecure."
+        insert_config "CSRF_TRUSTED_ORIGINS" "[\"${SITE_ROOT}\"]"
     fi
     if [[ -n ${PING_BODY_LIMIT} ]]; then
         insert_config "PING_BODY_LIMIT" "$(printf '%d\n' "${PING_BODY_LIMIT}")"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-healthchecks/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Closes #112 and #114

Logic for CSRF setting was wrong and causing inconsistent behaviour. We now default to the value of $SITE_ROOT if nothing is provided, otherwise set to the literal value of the CSRF_TRUSTED_ORIGINS env.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
